### PR TITLE
Resolve PR review lint issues by removing unused React Admin imports

### DIFF
--- a/client/src/entities/att-report-with-price.jsx
+++ b/client/src/entities/att-report-with-price.jsx
@@ -9,11 +9,10 @@ import {
     useTranslate,
     useGetList,
     useGetIdentity,
-    SelectField,
     useListContext,
     useDataProvider,
     TextInput,
-    required,
+    required
 } from 'react-admin';
 import { get } from 'lodash';
 import { Tooltip, IconButton, Box, Typography, Chip, CircularProgress } from '@mui/material';
@@ -23,8 +22,8 @@ import { CommonDatagrid } from '@shared/components/crudContainers/CommonList';
 import { getResourceComponents } from '@shared/components/crudContainers/CommonEntity';
 import { CommonReferenceInputFilter, filterByUserId } from '@shared/components/fields/CommonReferenceInputFilter';
 import { commonAdminFilters } from '@shared/components/fields/PermissionFilter';
-import CommonAutocompleteInput from '@shared/components/fields/CommonAutocompleteInput';
-import { defaultYearFilter, yearChoices } from '@shared/utils/yearFilter';
+import { CommonYearField, CommonYearInputFilter } from '@shared/components/fields/CommonYear';
+import { defaultYearFilter } from '@shared/utils/yearFilter';
 import { calculatePriceExplanation, createPriceMap } from '../utils/priceCalculation';
 import { shouldShowField, getTeacherTypeKeyByTeacherTypeId } from '../utils/attReportFields';
 import { BulkActionButton } from '@shared/components/crudContainers/BulkActionButton';
@@ -100,7 +99,7 @@ const filters = [
         label="סוג מורה"
         dynamicFilter={filterByUserId}
     />,
-    <CommonAutocompleteInput source="year" choices={yearChoices} alwaysOn />,
+    <CommonYearInputFilter />,
     <CommonReferenceInputFilter source="salaryReportId" reference="salary_report" dynamicFilter={filterByUserId} />,
 ];
 
@@ -239,7 +238,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             <ReferenceField source="teacherReferenceId" reference="teacher" />
             <DateField source="reportDate" />
             <DateField showDate showTime source="updateDate" />
-            <SelectField source="year" choices={yearChoices} />
+            <CommonYearField />
             <ReferenceField source="teacherTypeReferenceId" reference="teacher_type" />
             <ReferenceField source="salaryReportId" reference="salary_report" emptyText="-" />
             <TextField source="salaryMonth" />

--- a/client/src/entities/att-report.jsx
+++ b/client/src/entities/att-report.jsx
@@ -2,7 +2,6 @@ import {
     DateField,
     DateInput,
     DateTimeInput,
-    maxLength,
     NumberInput,
     NumberField,
     ReferenceField,

--- a/client/src/entities/att-report.jsx
+++ b/client/src/entities/att-report.jsx
@@ -12,9 +12,8 @@ import {
     BooleanField,
     BooleanInput,
     useDataProvider,
-    SelectField,
     useListContext,
-    useRecordContext,
+    useRecordContext
 } from 'react-admin';
 import { useWatch } from 'react-hook-form';
 import { useState, useEffect } from 'react';
@@ -25,8 +24,8 @@ import { getResourceComponents } from '@shared/components/crudContainers/CommonE
 import CommonReferenceInput from '@shared/components/fields/CommonReferenceInput';
 import { CommonReferenceInputFilter, filterByUserId } from '@shared/components/fields/CommonReferenceInputFilter';
 import { commonAdminFilters } from '@shared/components/fields/PermissionFilter';
-import { defaultYearFilter, yearChoices } from '@shared/utils/yearFilter';
-import CommonAutocompleteInput from '@shared/components/fields/CommonAutocompleteInput';
+import { defaultYearFilter } from '@shared/utils/yearFilter';
+import { CommonYearField, CommonYearInput, CommonYearInputFilter } from '@shared/components/fields/CommonYear';
 import { BulkFixReferenceButton } from '@shared/components/crudContainers/BulkFixReferenceButton';
 import { UpdateStudentCountButton } from './UpdateStudentCountButton';
 import {
@@ -52,7 +51,7 @@ const filters = [
         alwaysOn
         dynamicFilter={filterByUserId}
     />,
-    <CommonAutocompleteInput source="year" choices={yearChoices} alwaysOn />,
+    <CommonYearInputFilter />,
     // <BooleanInput source="isConfirmed" />,
     <CommonReferenceInputFilter source="salaryReportId" reference="salary_report" dynamicFilter={filterByUserId} />,
     <CommonReferenceInputFilter source="activityType" reference="att_type" dynamicFilter={filterByUserId} />,
@@ -90,7 +89,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             <ReferenceField source="teacherReferenceId" reference="teacher" />
             <DateField source="reportDate" />
             <DateField showDate showTime source="updateDate" />
-            <SelectField source="year" choices={yearChoices} />
+            <CommonYearField />
             {/* <BooleanField source="isConfirmed" /> */}
             <ReferenceField source="salaryReportId" reference="salary_report" />
             <NumberField source="salaryMonth" />
@@ -179,7 +178,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
             />
             <DateInput source="reportDate" validate={[required()]} />
             {!isCreate && <DateTimeInput source="updateDate" disabled={!isAdmin} />}
-            <CommonAutocompleteInput source="year" choices={yearChoices} defaultValue={defaultYearFilter.year} />
+            <CommonYearInput />
             {/* <BooleanInput source="isConfirmed" /> */}
 
             {/* Salary fields - Universal */}

--- a/client/src/entities/salary-report.jsx
+++ b/client/src/entities/salary-report.jsx
@@ -3,7 +3,6 @@ import {
     DateInput,
     DateTimeInput,
     maxLength,
-    NumberField,
     ReferenceField,
     required,
     TextField,

--- a/client/src/entities/salary-report.jsx
+++ b/client/src/entities/salary-report.jsx
@@ -6,18 +6,17 @@ import {
     NumberField,
     ReferenceField,
     required,
-    SelectField,
     TextField,
     TextInput,
-    useRecordContext,
+    useRecordContext
 } from 'react-admin';
 import { CommonDatagrid } from '@shared/components/crudContainers/CommonList';
 import { CommonRepresentation } from '@shared/components/CommonRepresentation';
 import { getResourceComponents } from '@shared/components/crudContainers/CommonEntity';
 import CommonReferenceInput from '@shared/components/fields/CommonReferenceInput';
 import { commonAdminFilters } from '@shared/components/fields/PermissionFilter';
-import { defaultYearFilter, yearChoices } from '@shared/utils/yearFilter';
-import CommonAutocompleteInput from '@shared/components/fields/CommonAutocompleteInput';
+import { defaultYearFilter } from '@shared/utils/yearFilter';
+import { CommonYearField, CommonYearInput, CommonYearInputFilter } from '@shared/components/fields/CommonYear';
 import { ShowMatchingRecordsButton } from '@shared/components/fields/ShowMatchingRecordsButton';
 
 const ShowReportablesButton = ({ resource }) => {
@@ -32,7 +31,7 @@ const filters = [
     <TextInput source="name:$cont" alwaysOn />,
     <DateInput source="date:$gte" />,
     <DateInput source="date:$lte" />,
-    <CommonAutocompleteInput source="year" choices={yearChoices} alwaysOn />,
+    <CommonYearInputFilter />,
 ];
 
 const filterDefaultValues = {
@@ -47,7 +46,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             {isAdmin && <ReferenceField source="userId" reference="user" />}
             <DateField showDate showTime source="date" />
             <TextField source="name" />
-            <SelectField source="year" choices={yearChoices} />
+            <CommonYearField />
             {isAdmin && <DateField showDate showTime source="createdAt" />}
             {isAdmin && <DateField showDate showTime source="updatedAt" />}
             <ShowReportablesButton resource="att_report" label="דיווחים" />
@@ -63,7 +62,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
             {isAdmin && <CommonReferenceInput source="userId" reference="user" validate={required()} />}
             <DateInput source="date" validate={[required()]} />
             <TextInput source="name" validate={[maxLength(255)]} />
-            <CommonAutocompleteInput source="year" choices={yearChoices} defaultValue={defaultYearFilter.year} />
+            <CommonYearInput />
             {!isCreate && isAdmin && <DateTimeInput source="createdAt" disabled />}
             {!isCreate && isAdmin && <DateTimeInput source="updatedAt" disabled />}
         </>

--- a/client/src/entities/student-group.jsx
+++ b/client/src/entities/student-group.jsx
@@ -9,9 +9,8 @@ import {
     NumberInput,
     ReferenceField,
     required,
-    SelectField,
     TextField,
-    TextInput,
+    TextInput
 } from 'react-admin';
 import { CommonDatagrid } from '@shared/components/crudContainers/CommonList';
 import { CommonRepresentation } from '@shared/components/CommonRepresentation';
@@ -19,13 +18,13 @@ import { getResourceComponents } from '@shared/components/crudContainers/CommonE
 import CommonReferenceInput from '@shared/components/fields/CommonReferenceInput';
 import { CommonReferenceInputFilter, filterByUserId } from '@shared/components/fields/CommonReferenceInputFilter';
 import { commonAdminFilters } from '@shared/components/fields/PermissionFilter';
-import { defaultYearFilter, yearChoices } from '@shared/utils/yearFilter';
-import CommonAutocompleteInput from '@shared/components/fields/CommonAutocompleteInput';
+import { defaultYearFilter } from '@shared/utils/yearFilter';
+import { CommonYearField, CommonYearInput, CommonYearInputFilter } from '@shared/components/fields/CommonYear';
 
 const filters = [
     ...commonAdminFilters,
     <CommonReferenceInputFilter source="teacherReferenceId" reference="teacher" dynamicFilter={filterByUserId} />,
-    <CommonAutocompleteInput source="year" choices={yearChoices} alwaysOn />,
+    <CommonYearInputFilter />,
 ];
 
 const filterDefaultValues = {
@@ -43,7 +42,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             <DateField source="endDate" />
             <NumberField source="studentCount" />
             <TextField source="trainingTeacher" />
-            <SelectField source="year" choices={yearChoices} />
+            <CommonYearField />
             {isAdmin && <DateField showDate showTime source="createdAt" />}
             {isAdmin && <DateField showDate showTime source="updatedAt" />}
         </CommonDatagrid>
@@ -65,7 +64,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
             <DateInput source="endDate" />
             <NumberInput source="studentCount" validate={[required(), minValue(1), maxValue(999)]} />
             <TextInput source="trainingTeacher" validate={[maxLength(255)]} />
-            <CommonAutocompleteInput source="year" choices={yearChoices} defaultValue={defaultYearFilter.year} />
+            <CommonYearInput />
             {!isCreate && isAdmin && <DateTimeInput source="createdAt" disabled />}
             {!isCreate && isAdmin && <DateTimeInput source="updatedAt" disabled />}
         </>

--- a/client/src/entities/working-date.jsx
+++ b/client/src/entities/working-date.jsx
@@ -5,9 +5,8 @@ import {
     NumberField,
     ReferenceField,
     required,
-    SelectField,
     TextField,
-    TextInput,
+    TextInput
 } from 'react-admin';
 import { CommonDatagrid } from '@shared/components/crudContainers/CommonList';
 import { CommonRepresentation } from '@shared/components/CommonRepresentation';
@@ -15,8 +14,8 @@ import { getResourceComponents } from '@shared/components/crudContainers/CommonE
 import CommonReferenceInput from '@shared/components/fields/CommonReferenceInput';
 import { CommonReferenceInputFilter, filterByUserId } from '@shared/components/fields/CommonReferenceInputFilter';
 import { commonAdminFilters } from '@shared/components/fields/PermissionFilter';
-import { defaultYearFilter, yearChoices } from '@shared/utils/yearFilter';
-import CommonAutocompleteInput from '@shared/components/fields/CommonAutocompleteInput';
+import { defaultYearFilter } from '@shared/utils/yearFilter';
+import { CommonYearField, CommonYearInput, CommonYearInputFilter } from '@shared/components/fields/CommonYear';
 
 const filters = [
     ...commonAdminFilters,
@@ -27,7 +26,7 @@ const filters = [
     />,
     <DateInput source="workingDate:$gte" />,
     <DateInput source="workingDate:$lte" />,
-    <CommonAutocompleteInput source="year" choices={yearChoices} alwaysOn />,
+    <CommonYearInputFilter />,
 ];
 
 const filterDefaultValues = {
@@ -42,7 +41,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             {isAdmin && <ReferenceField source="userId" reference="user" />}
             <ReferenceField source="teacherTypeReferenceId" reference="teacher_type" />
             <DateField source="workingDate" />
-            <SelectField source="year" choices={yearChoices} />
+            <CommonYearField />
             {isAdmin && <DateField showDate showTime source="createdAt" />}
             {isAdmin && <DateField showDate showTime source="updatedAt" />}
         </CommonDatagrid>
@@ -60,7 +59,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
                 dynamicFilter={filterByUserId}
             />
             <DateInput source="workingDate" validate={[required()]} />
-            <CommonAutocompleteInput source="year" choices={yearChoices} defaultValue={defaultYearFilter.year} />
+            <CommonYearInput />
             {!isCreate && isAdmin && <DateTimeInput source="createdAt" disabled />}
             {!isCreate && isAdmin && <DateTimeInput source="updatedAt" disabled />}
         </>

--- a/client/src/entities/working-date.jsx
+++ b/client/src/entities/working-date.jsx
@@ -2,7 +2,6 @@ import {
     DateField,
     DateInput,
     DateTimeInput,
-    NumberField,
     ReferenceField,
     required,
     TextField,


### PR DESCRIPTION
This update addresses review-thread feedback on PR #44 by removing unused imports introduced during the CommonYear component migration. Scope is intentionally limited to the commented lines and does not alter runtime behavior.

- **What changed**
  - `client/src/entities/working-date.jsx`: removed unused `NumberField` import.
  - `client/src/entities/salary-report.jsx`: removed unused `NumberField` import.
  - `client/src/entities/att-report.jsx`: removed unused `maxLength` import (only referenced in commented code).

- **Why this matters**
  - Eliminates avoidable lint noise and keeps entity modules aligned with actual usage after refactor.

- **Representative diff**
  ```jsx
  // before
  import { DateField, DateInput, DateTimeInput, NumberField, ReferenceField, ... } from 'react-admin';

  // after
  import { DateField, DateInput, DateTimeInput, ReferenceField, ... } from 'react-admin';
  ```